### PR TITLE
changes on read_layout

### DIFF
--- a/.idea/cglumberjack.iml
+++ b/.idea/cglumberjack.iml
@@ -7,6 +7,7 @@
       <excludeFolder url="file://$MODULE_DIR$/cgl/plugins/project_management/shotgun/shotgun_api3" />
       <excludeFolder url="file://$MODULE_DIR$/python27venv" />
       <excludeFolder url="file://$MODULE_DIR$/python38_fixvenv" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (cglumberjack)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/cgl/plugins/blender/utils.py
+++ b/cgl/plugins/blender/utils.py
@@ -199,7 +199,7 @@ def write_layout(outFile = None):
     from pathlib import Path
     import json
     if outFile == None:
-        outFile = scene_object().copy(ext = 'json').path_root
+        outFile = scene_object().copy(ext='json', task='lay', user='publish').path_root
     data = {}
 
     for obj in bpy.data.objects:
@@ -235,7 +235,14 @@ def read_layout(outFile = None ):
     import bpy
 
     if outFile == None:
-        outFile = scene_object().copy(ext='json').path_root
+
+        outFileObject = scene_object().copy(ext='json', task='lay', user='publish').latest_version()
+        outFileObject.set_attr(filename='%s_%s_%s.%s' % (outFileObject.seq,
+                                                       outFileObject.shot,
+                                                       outFileObject.task,
+                                                       'json'
+                                                       ))
+        outFile= outFileObject.path_root
     #outFile = scene_object().path_root.replace(scene_object().ext, 'json')
 
     with open(outFile) as json_file:
@@ -266,6 +273,7 @@ def read_layout(outFile = None ):
                 obj.scale = (transform_data[6],transform_data[7],transform_data[8])
 
     bpy.ops.file.make_paths_relative()
+
 
 
 


### PR DESCRIPTION
working on the read_layout for blender just fixed the way it get's called so that it always points to the latest layout published file 