### PR TITLE
fix setSortingEnabled to false on  the update status for the preflight window that way it doesnt change the order, and forced it to update by preflight order.

### DIFF
--- a/cgl/plugins/blender/lumbermill.py
+++ b/cgl/plugins/blender/lumbermill.py
@@ -309,7 +309,7 @@ def export_selected(to_path):
         bpy.ops.export_scene.blend(filepath=to_path, use_selection=True)
 
 
-def create_turntable(length=180, task=False):
+def create_turntable(length=250, task=False):
     """
     Creates a Turntable of length around the selected object, or around a "task" object.
     This is specific to 3d applications.
@@ -317,6 +317,33 @@ def create_turntable(length=180, task=False):
     :param task:
     :return:
     """
+    distanceFromObject = objectDimensions[0] * -4
+
+    selectedObject = bpy.context.object
+    objectDimensions = selectedObject.dimensions
+
+    height = objectDimensions[2] / 2
+    height = objectDimensions[2] / 2
+
+    #Creates locator top parent camera to
+    locator = bpy.data.objects.new('TurnTableLocator', None)
+    locator.empty_display_size = 2
+    locator.empty_display_type = 'PLAIN_AXES'
+    bpy.context.scene.collection.objects.link(locator)
+    #Create camera
+    turnTableCamObj = bpy.data.cameras.new('turnTable')
+    turnTable = bpy.data.objects.new("TurnTableCam", turnTableCamObj)
+    bpy.context.scene.collection.objects.link(turnTable)
+    turnTable.parent = locator
+
+    turnTable.location = (0, distanceFromObject, height)
+    turnTable.rotation_euler = (1.5707963705062866, 0.0, 0.0)
+    #Animates TurnTable
+    locator.keyframe_insert("rotation_euler", frame=1)
+    locator.rotation_euler = (0, 0, 6.2831854820251465)
+    locator.keyframe_insert("rotation_euler", frame=lenght)
+
+    locator.animation_data.action.fcurves[2].keyframe_points[0].interpolation = 'LINEAR'
     pass
 
 
@@ -325,6 +352,13 @@ def clean_turntable():
     cleans up the turntable
     :return:
     """
+    objs = bpy.data.objects
+    remove = ['TurnTableLocator', 'TurnTableCam']
+
+    for removeName in remove:
+        for obj in objs:
+            if obj.name == removeName:
+                objs.remove(objs[obj.name], do_unlink=True)
     pass
 
 

--- a/cgl/plugins/blender/lumbermill.py
+++ b/cgl/plugins/blender/lumbermill.py
@@ -317,13 +317,13 @@ def create_turntable(length=250, task=False):
     :param task:
     :return:
     """
-    distanceFromObject = objectDimensions[0] * -4
+
 
     selectedObject = bpy.context.object
     objectDimensions = selectedObject.dimensions
-
+    distanceFromObject = objectDimensions[0] * -4
     height = objectDimensions[2] / 2
-    height = objectDimensions[2] / 2
+    lenght = 250
 
     #Creates locator top parent camera to
     locator = bpy.data.objects.new('TurnTableLocator', None)

--- a/cgl/plugins/blender/utils.py
+++ b/cgl/plugins/blender/utils.py
@@ -275,7 +275,61 @@ def read_layout(outFile = None ):
     bpy.ops.file.make_paths_relative()
 
 
+def rename_materials(selection = None):
+    import bpy
+    """
+    Sequentially renames  materials from given object name if empty , renamed from selected object
+    :param name:
+    """
+    if selection == None:
+        selection = bpy.context.selected_objects
 
+
+        for object in selection:
+            for material_slot in object.material_slots:
+                material_slot.material.name = object.name
+                print(object.name, material_slot.name)
+
+    if selection:
+        selection = [bpy.data.objects[selection]]
+        for object in selection:
+            for material_slot in object.material_slots:
+                material_slot.material.name = object.name
+                print(object.name, material_slot.name)
+
+
+def setup_preview_viewport_display(color=None, selection=None):
+    import bpy
+    """
+    set up the default viewport display color  diffuse_color on materials
+    :param color: Value of the color  of the parent menu  FloatProperty 4
+    :param selection:
+    """
+    if selection == None:
+        selection = bpy.context.selected_objects
+
+
+    for object in selection:
+        for material_slot in object.material_slots:
+            material = material_slot.material
+            node_tree = material.node_tree.nodes
+            if color == None:
+                for node in node_tree:
+                    if node.type == 'OUTPUT_MATERIAL':
+                        for input in node.inputs:
+                            if len(input.links) != 0:
+                                input_surface = input.links[0].from_node
+                                color_input = input_surface.inputs[0]
+                                try:
+                                    color_input_nested = color_input.links[0].from_node
+                                    color_input.default_value = color_input_nested.outputs[0].default_value
+                                except(IndexError):
+                                    print('no color inputs found. Using Default')
+                                    pass
+
+                                material.diffuse_color = color_input.default_value
+            else:
+                material_slot.material.diffuse_color = color
 
 
 if __name__ == '__main__':

--- a/cgl/plugins/preflight/main.py
+++ b/cgl/plugins/preflight/main.py
@@ -258,8 +258,10 @@ class Preflight(QtWidgets.QWidget):
         # refresh the table with self.table_data
         self.preflights.set_item_model(PreflightModel(self.table_data,
                                                       ["Check", "Status", "Path", "Order", "Required"]))
+        self.preflights.sortByColumn(3, QtCore.Qt.SortOrder(0))
         self.preflights.hideColumn(2)
         self.preflights.hideColumn(3)
+        self.preflights.setSortingEnabled(False)
 
     def run_all_clicked(self):
         # To Do: load waiting gif while function operates


### PR DESCRIPTION
Fixed error on the update prefligh funcition where it would mess up the sorting order of preflights

Added create_turntable and clean_turntable code to the blender lumbermill plugin

Added rename_materials and setup_preview_viewport_display to utils